### PR TITLE
Pin version built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,11 @@ RUN apk --no-cache add \
       linux-headers \
       upx
 
-RUN git clone --depth 1 --branch "${VERSION}" https://gitlab.com/lars-thrane-as/ttynvt.git /ttynvt
+RUN git clone https://gitlab.com/lars-thrane-as/ttynvt.git /ttynvt
 
 WORKDIR /ttynvt
+
+RUN git checkout e51a98e4b270002c2bb0bcca4452e74b8ec9c8d2
 
 # Copy header files and static library
 COPY --from=libfuse /libfuse/lib/.libs/libfuse.a /lib/fuse/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN CORES=$(grep -c '^processor' /proc/cpuinfo); \
 ARG ARCHITECTURE
 FROM multiarch/alpine:${ARCHITECTURE}-v3.12 as builder
 
-ENV VERSION=master
+ENV VERSION=v0.15
 
 # Add root without shell
 RUN echo "root:x:0:0:root:/:" > /etc_passwd
@@ -52,11 +52,9 @@ RUN apk --no-cache add \
       linux-headers \
       upx
 
-RUN git clone https://gitlab.com/lars-thrane-as/ttynvt.git /ttynvt
+RUN git clone --depth 1 --branch "${VERSION}" https://gitlab.com/lars-thrane-as/ttynvt.git /ttynvt
 
 WORKDIR /ttynvt
-
-RUN git checkout e51a98e4b270002c2bb0bcca4452e74b8ec9c8d2
 
 # Copy header files and static library
 COPY --from=libfuse /libfuse/lib/.libs/libfuse.a /lib/fuse/
@@ -67,14 +65,12 @@ ENV FUSE_CFLAGS="-I/usr/include/fuse" \
     FUSE_LIBS="-lfuse -L/lib/fuse"
 
 # Makeflags source: https://math-linux.com/linux/tip-of-the-day/article/speedup-gnu-make-build-and-compilation-process
-# -Wno-cpp is needed for:
-# /usr/include/sys/poll.h:1:2: error: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Werror=cpp]
 RUN CORES=$(grep -c '^processor' /proc/cpuinfo); \
     export MAKEFLAGS="-j$((CORES+1)) -l${CORES}"; \
     autoreconf -vif && \
     ./configure && \
     make \
-      CFLAGS="-Wall -O3 -static -Wno-cpp -D_FILE_OFFSET_BITS=64"
+      CFLAGS="-Wall -O3 -static -D_FILE_OFFSET_BITS=64"
 
 # Minify binaries
 # --brute does not work


### PR DESCRIPTION
Pin the version of ttynvt built to a tag instead of a branch to make the container more reproducible. As part of pinning the version, upgrade to the v0.15 tag. That tag is the first tag created after this repository's inception.